### PR TITLE
enable node selector

### DIFF
--- a/user_n/oai-e2e/oai-cu/values.yaml
+++ b/user_n/oai-e2e/oai-cu/values.yaml
@@ -90,4 +90,4 @@ terminationGracePeriodSeconds: 5
 
 nodeSelector: {}
 
-# nodeName: node3
+nodeName: node3

--- a/user_n/oai-e2e/oai-du/values.yaml
+++ b/user_n/oai-e2e/oai-du/values.yaml
@@ -115,4 +115,4 @@ terminationGracePeriodSeconds: 5
 
 nodeSelector: {}
 
-# nodeName: node3
+nodeName: node2

--- a/user_n/oai-e2e/oai-nr-ue/values.yaml
+++ b/user_n/oai-e2e/oai-nr-ue/values.yaml
@@ -86,4 +86,4 @@ terminationGracePeriodSeconds: 0
 
 nodeSelector: {}
 
-# nodeName: node3
+nodeName: node3

--- a/user_n/oai-multi-gnb/oai-cu/values.yaml
+++ b/user_n/oai-multi-gnb/oai-cu/values.yaml
@@ -134,4 +134,4 @@ terminationGracePeriodSeconds: 5
 
 nodeSelector: {}
 
-# nodeName: node3
+nodeName: node3

--- a/user_n/oai-multi-gnb/oai-du-1/values.yaml
+++ b/user_n/oai-multi-gnb/oai-du-1/values.yaml
@@ -122,4 +122,4 @@ terminationGracePeriodSeconds: 5
 
 nodeSelector: {}
 
-# nodeName: node3
+nodeName: node2

--- a/user_n/oai-multi-gnb/oai-du-2/values.yaml
+++ b/user_n/oai-multi-gnb/oai-du-2/values.yaml
@@ -122,4 +122,4 @@ terminationGracePeriodSeconds: 5
 
 nodeSelector: {}
 
-# nodeName: node3
+nodeName: node2

--- a/user_n/oai-multi-gnb/oai-nr-ue-1/values.yaml
+++ b/user_n/oai-multi-gnb/oai-nr-ue-1/values.yaml
@@ -87,4 +87,4 @@ terminationGracePeriodSeconds: 0
 
 nodeSelector: {}
 
-# nodeName: node3
+nodeName: node3

--- a/user_n/oai-multi-gnb/oai-nr-ue-2/values.yaml
+++ b/user_n/oai-multi-gnb/oai-nr-ue-2/values.yaml
@@ -87,4 +87,4 @@ terminationGracePeriodSeconds: 0
 
 nodeSelector: {}
 
-# nodeName: node3
+nodeName: node3

--- a/user_n/oai-multi-ue/oai-cu/values.yaml
+++ b/user_n/oai-multi-ue/oai-cu/values.yaml
@@ -131,4 +131,4 @@ terminationGracePeriodSeconds: 5
 
 nodeSelector: {}
 
-# nodeName: node3
+nodeName: node3

--- a/user_n/oai-multi-ue/oai-du/values.yaml
+++ b/user_n/oai-multi-ue/oai-du/values.yaml
@@ -121,4 +121,4 @@ terminationGracePeriodSeconds: 5
 
 nodeSelector: {}
 
-# nodeName: node3
+nodeName: node2

--- a/user_n/oai-multi-ue/oai-nr-ue-1/values.yaml
+++ b/user_n/oai-multi-ue/oai-nr-ue-1/values.yaml
@@ -87,4 +87,4 @@ terminationGracePeriodSeconds: 0
 
 nodeSelector: {}
 
-# nodeName: node3
+nodeName: node3

--- a/user_n/oai-multi-ue/oai-nr-ue-2/values.yaml
+++ b/user_n/oai-multi-ue/oai-nr-ue-2/values.yaml
@@ -87,4 +87,4 @@ terminationGracePeriodSeconds: 0
 
 nodeSelector: {}
 
-# nodeName: node3
+nodeName: node3


### PR DESCRIPTION
i just enable node selector for each components because the existing pod scheduler always map all components into node3.

this is the node mapping of each components:
DU = node2
CU = node3
UE = node3